### PR TITLE
Upgrade PureScript 0.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,54 @@
 {
   "name": "purescript-yaml-next",
+  "lockfileVersion": 2,
   "requires": true,
-  "lockfileVersion": 1,
+  "packages": {
+    "": {
+      "hasInstallScript": true,
+      "license": "SEE LICENSE FILE",
+      "dependencies": {
+        "js-yaml": "^3.13.1"
+      },
+      "devDependencies": {}
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    }
+  },
   "dependencies": {
     "argparse": {
       "version": "1.0.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,75 +7,40 @@
       "hasInstallScript": true,
       "license": "SEE LICENSE FILE",
       "dependencies": {
-        "js-yaml": "^3.13.1"
+        "js-yaml": "^4.0.0"
       },
       "devDependencies": {}
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+      "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     }
   },
   "dependencies": {
     "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+      "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       }
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "contributors": [],
   "main": "main.js",
   "scripts": {
+    "test": "spago test",
     "postinstall": "spago build"
   },
   "devDependencies": {},
   "dependencies": {
-    "js-yaml": "^3.13.1"
+    "js-yaml": "^4.0.0"
   }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,5 +1,5 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.3-20191005/packages.dhall sha256:ba287d858ada09c4164792ad4e643013b742c208cbedf5de2e35ee27b64b6817
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210317/packages.dhall sha256:e2e744972f9b60188dcf07f41418661b505c9ee2e9f91e57e67daefad3a5ae09
 
 let overrides = {=}
 

--- a/spago.dhall
+++ b/spago.dhall
@@ -6,7 +6,6 @@
     , "console"
     , "effect"
     , "foreign"
-    , "foreign-generic"
     , "functions"
     , "ordered-collections"
     , "psci-support"

--- a/src/Data/YAML/Foreign/Decode.js
+++ b/src/Data/YAML/Foreign/Decode.js
@@ -4,7 +4,7 @@ var yaml = require('js-yaml');
 
 exports.parseYAMLImpl = function(left, right, str) {
   try {
-    return right(yaml.safeLoad(str));
+    return right(yaml.load(str));
   } catch (e) {
     return left(e.toString());
   }

--- a/src/Data/YAML/Foreign/Decode.purs
+++ b/src/Data/YAML/Foreign/Decode.purs
@@ -1,27 +1,23 @@
-module Data.YAML.Foreign.Decode (
-  readYAMLGeneric,
-  parseYAMLToJson
-  ) where
+module Data.YAML.Foreign.Decode (parseYAMLToJson)
+where
 
 import Foreign (F, Foreign, ForeignError(..), fail)
-import Foreign.Generic (genericDecode)
-import Foreign.Generic.Class (class GenericDecode, Options)
 import Data.Function.Uncurried (Fn3, runFn3)
-import Data.Generic.Rep (class Generic)
-import Prelude ((>=>), (<<<), pure, (>>=))
+import Prelude (pure, (<<<), (>>=))
 import Unsafe.Coerce (unsafeCoerce)
 import Data.Argonaut.Core (Json)
 
-foreign import parseYAMLImpl :: forall r. Fn3 (String -> r) (Foreign -> r) String r
+foreign import parseYAMLImpl :: forall r.
+  Fn3 (String -> r) (Foreign -> r) String r
+
 
 -- | Attempt to parse a YAML string, returning the result as foreign data.
 parseYAML :: String -> F Foreign
-parseYAML yaml = runFn3 parseYAMLImpl (fail <<< ForeignError) pure yaml
+parseYAML yaml =
+  runFn3 parseYAMLImpl (fail <<< ForeignError) pure yaml
+
 
 -- | Attempt to parse a YAML string, returning the result as Json
 parseYAMLToJson :: String -> F Json
-parseYAMLToJson yaml = parseYAML yaml >>= pure <<< unsafeCoerce
-
--- | Automatically generate a YAML parser for your data from a generic instance.
-readYAMLGeneric :: forall a rep. (Generic a rep) => (GenericDecode rep) => Options -> String -> F a
-readYAMLGeneric opts = parseYAML >=> genericDecode opts
+parseYAMLToJson yaml =
+  parseYAML yaml >>= pure <<< unsafeCoerce

--- a/src/Data/YAML/Foreign/Encode.js
+++ b/src/Data/YAML/Foreign/Encode.js
@@ -14,5 +14,5 @@ exports.objToHash = function(valueToYAMLImpl, fst, snd, obj) {
 
 exports.toYAMLImpl = function(a) {
 	// noCompatMode does not support YAML 1.1
-	return yaml.safeDump(a, {noCompatMode : true});
+	return yaml.dump(a, {noCompatMode : true});
 }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,6 +2,7 @@ module Test.Main where
 
 import Control.Monad.Except (runExcept)
 import Data.Argonaut.Decode (class DecodeJson, decodeJson)
+import Data.Argonaut.Decode.Error (printJsonDecodeError)
 import Data.Either (Either(..))
 import Data.Map (Map)
 import Data.Map as Map
@@ -103,8 +104,10 @@ Y: 1
 
 yamlToData :: forall a. (DecodeJson a) => String -> Either String a
 yamlToData s = case runExcept $ parseYAMLToJson s of
-  Left err -> Left "Could not parse yaml"
-  Right json -> decodeJson json
+  Left err -> Left "Could not parse YAML"
+  Right json -> case decodeJson json of
+    Left error -> Left $ printJsonDecodeError error
+    Right value -> Right value
 
 
 testMap :: Map String (Array GeoObject)


### PR DESCRIPTION
I removed the function `readYAMLGeneric` since `foreign-generic` will probably not be upgraded to 0.14. Since this package isn't really distributed anywhere currently, I don't think it's a problem that it's a breaking change. Could be reimplemented in a future version with the default generics I guess.

I'd release a new version once this merged and add it to package-sets, ok?